### PR TITLE
Improve content for less experienced audience

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -47,8 +47,14 @@ flowchart LR
 
 Choose the path that best fits your needs:
 
-#### Quick Starts
 <CardGroup cols={2}>
+  <Card
+    title="Quickstart"
+    icon="bolt"
+    href="/quickstart/quick"
+  >
+    Learn the core features of MCP
+  </Card>
   <Card
     title="For Server Developers"
     icon="bolt"

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -7,6 +7,26 @@ description: 'Get started with the Model Context Protocol (MCP)'
 
 MCP is an open protocol that standardizes how applications provide context to LLMs. Think of MCP like a USB-C port for AI applications. Just as USB-C provides a standardized way to connect your devices to various peripherals and accessories, MCP provides a standardized way to connect AI models to different data sources and tools.
 
+Explore the applications that support MCP integrations and trusted examples of MCP servers that demonstrate what the protocol can do.
+
+<CardGroup cols={2}>
+    <Card
+    title="Example Clients"
+    icon="cubes"
+    href="/clients"
+  >
+    View the list of clients that support MCP integrations
+  </Card>
+  <Card
+    title="Example Servers"
+    icon="grid"
+    href="/examples"
+  >
+    Check out our gallery of official MCP servers and implementations
+  </Card>
+</CardGroup>
+
+
 ## Why MCP?
 
 MCP helps you build agents and complex workflows on top of LLMs. LLMs frequently need to integrate with data and tools, and MCP provides:
@@ -43,25 +63,9 @@ We reccomend reading the quickstart guides in the following order:
   </Card>
 </CardGroup>
 
-#### Examples
-<CardGroup cols={2}>
-  <Card
-    title="Example Servers"
-    icon="grid"
-    href="/examples"
-  >
-    Check out our gallery of official MCP servers and implementations
-  </Card>
-  <Card
-    title="Example Clients"
-    icon="cubes"
-    href="/clients"
-  >
-    View the list of clients that support MCP integrations
-  </Card>
-</CardGroup>
-
 ## Tutorials
+
+Develop your understanding and capacity to use MCPs with these tutorials.
 
 <CardGroup cols={2}>
   <Card

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -10,9 +10,10 @@ MCP is an open protocol that standardizes how applications provide context to LL
 ## Why MCP?
 
 MCP helps you build agents and complex workflows on top of LLMs. LLMs frequently need to integrate with data and tools, and MCP provides:
-- A growing list of pre-built integrations that your LLM can directly plug into
-- The flexibility to switch between LLM providers and vendors
-- Best practices for securing your data within your infrastructure
+- Predictability: Help ensure the LLM behaves as expected by providing the proper context
+- Efficiency: A growing list of pre-built integrations that your LLM can directly plug into 
+- Flexibility: The ability to switch between LLM providers and vendors
+- Security: Clear context boudaries and best practices for securing your data within your infrastructure
 
 ### General architecture
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -17,36 +17,29 @@ MCP helps you build agents and complex workflows on top of LLMs. LLMs frequently
 
 ## Get started
 
-Choose the path that best fits your needs:
+We reccomend reading the quickstart guides in the following order:
 
-<CardGroup cols={2}>
-  <Card
-    title="Quickstart"
-    icon="bolt"
-    href="/quickstart/quick"
-  >
-    Learn the core features of MCP
-  </Card>
-  <Card
-    title="For Server Developers"
-    icon="bolt"
-    href="/quickstart/server"
-  >
-    Get started building your own server to use in Claude for Desktop and other clients
-  </Card>
-  <Card
-    title="For Client Developers"
-    icon="bolt"
-    href="/quickstart/client"
-  >
-    Get started building your own client that can integrate with all MCP servers
-  </Card>
+<CardGroup cols={1}>
   <Card
     title="For Claude Desktop Users"
     icon="bolt"
     href="/quickstart/user"
   >
     Get started using pre-built servers in Claude for Desktop
+  </Card>
+  <Card
+    title="For Server Developers"
+    icon="bolt"
+    href="/quickstart/server"
+  >
+    Set up your own server to use in Claude for Desktop and other clients
+  </Card>
+  <Card
+    title="For Client Developers"
+    icon="bolt"
+    href="/quickstart/client"
+  >
+    Build your own client that can integrate with all MCP servers
   </Card>
 </CardGroup>
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -15,7 +15,7 @@ MCP helps you build agents and complex workflows on top of LLMs. LLMs frequently
 - Flexibility: The ability to switch between LLM providers and vendors
 - Security: Clear context boudaries and best practices for securing your data within your infrastructure
 
-### General architecture
+## General architecture
 
 At its core, MCP follows a client-server architecture where a host application can connect to multiple servers:
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -7,6 +7,14 @@ description: 'Get started with the Model Context Protocol (MCP)'
 
 MCP is an open protocol that standardizes how applications provide context to LLMs. Think of MCP like a USB-C port for AI applications. Just as USB-C provides a standardized way to connect your devices to various peripherals and accessories, MCP provides a standardized way to connect AI models to different data sources and tools.
 
+## Why MCP?
+
+MCP helps you build agents and complex workflows on top of LLMs. LLMs frequently need to integrate with data and tools, and MCP provides:
+- Predictability: Help ensure the LLM behaves as expected by providing the proper context
+- Efficiency: A growing list of pre-built integrations that your LLM can directly plug into 
+- Flexibility: The ability to switch between LLM providers and vendors
+- Security: Clear context boudaries and best practices for securing your data within your infrastructure
+
 Explore the applications that support MCP integrations and trusted examples of MCP servers that demonstrate what the protocol can do.
 
 <CardGroup cols={2}>
@@ -25,15 +33,6 @@ Explore the applications that support MCP integrations and trusted examples of M
     Check out our gallery of official MCP servers and implementations
   </Card>
 </CardGroup>
-
-
-## Why MCP?
-
-MCP helps you build agents and complex workflows on top of LLMs. LLMs frequently need to integrate with data and tools, and MCP provides:
-- Predictability: Help ensure the LLM behaves as expected by providing the proper context
-- Efficiency: A growing list of pre-built integrations that your LLM can directly plug into 
-- Flexibility: The ability to switch between LLM providers and vendors
-- Security: Clear context boudaries and best practices for securing your data within your infrastructure
 
 ## Get started
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -15,34 +15,6 @@ MCP helps you build agents and complex workflows on top of LLMs. LLMs frequently
 - Flexibility: The ability to switch between LLM providers and vendors
 - Security: Clear context boudaries and best practices for securing your data within your infrastructure
 
-## General architecture
-
-At its core, MCP follows a client-server architecture where a host application can connect to multiple servers:
-
-```mermaid
-flowchart LR
-    subgraph "Your Computer"
-        Host["Host with MCP Client\n(Claude, IDEs, Tools)"]
-        S1["MCP Server A"]
-        S2["MCP Server B"]
-        S3["MCP Server C"]
-        Host <-->|"MCP Protocol"| S1
-        Host <-->|"MCP Protocol"| S2
-        Host <-->|"MCP Protocol"| S3
-        S1 <--> D1[("Local\nData Source A")]
-        S2 <--> D2[("Local\nData Source B")]
-    end
-    subgraph "Internet"
-        S3 <-->|"Web APIs"| D3[("Remote\nService C")]
-    end
-```
-
-- **MCP Hosts**: Programs like Claude Desktop, IDEs, or AI tools that want to access data through MCP
-- **MCP Clients**: Protocol clients that maintain 1:1 connections with servers
-- **MCP Servers**: Lightweight programs that each expose specific capabilities through the standardized Model Context Protocol
-- **Local Data Sources**: Your computer's files, databases, and services that MCP servers can securely access
-- **Remote Services**: External systems available over the internet (e.g., through APIs) that MCP servers can connect to
-
 ## Get started
 
 Choose the path that best fits your needs:
@@ -129,6 +101,34 @@ Choose the path that best fits your needs:
 </CardGroup>
 
 ## Explore MCP
+
+### General architecture
+
+At its core, MCP follows a client-server architecture where a host application can connect to multiple servers:
+
+```mermaid
+flowchart LR
+    subgraph "Your Computer"
+        Host["Host with MCP Client\n(Claude, IDEs, Tools)"]
+        S1["MCP Server A"]
+        S2["MCP Server B"]
+        S3["MCP Server C"]
+        Host <-->|"MCP Protocol"| S1
+        Host <-->|"MCP Protocol"| S2
+        Host <-->|"MCP Protocol"| S3
+        S1 <--> D1[("Local\nData Source A")]
+        S2 <--> D2[("Local\nData Source B")]
+    end
+    subgraph "Internet"
+        S3 <-->|"Web APIs"| D3[("Remote\nService C")]
+    end
+```
+
+- **MCP Hosts**: Programs like Claude Desktop, IDEs, or AI tools that want to access data through MCP
+- **MCP Clients**: Protocol clients that maintain 1:1 connections with servers
+- **MCP Servers**: Lightweight programs that each expose specific capabilities through the standardized Model Context Protocol
+- **Local Data Sources**: Your computer's files, databases, and services that MCP servers can securely access
+- **Remote Services**: External systems available over the internet (e.g., through APIs) that MCP servers can connect to
 
 Dive deeper into MCP's core concepts and capabilities:
 

--- a/docs/quickstart/quick.mdx
+++ b/docs/quickstart/quick.mdx
@@ -1,5 +1,0 @@
----
-title: "Quickstart"
-description: "Learn the core skills of working with MCPs."
----
-

--- a/docs/quickstart/quick.mdx
+++ b/docs/quickstart/quick.mdx
@@ -1,0 +1,5 @@
+---
+title: "Quickstart"
+description: "Learn the core skills of working with MCPs."
+---
+


### PR DESCRIPTION
This PR makes the following improvements to the https://modelcontextprotocol.io/ docs with the goal of making the content more accessible to less experienced users.

* **Why MCP?**
  * Add keywords that communicate the value of MCP so that someone scanning the page picks up on why MCP might be important or useful to them
  * Group conceptual content together at the beginning
    * The "Examples" cards help contextualize where you use MCP and what it can do, so I moved them to the beginning to prime people with less understanding
* **Get started**
  * I wanted to guide people along a suggested path rather than just leave them to click around each quickstart. The flow of desktop -> server -> client takes someone from completing a fairly out-of-the-box setup to preparing them to create custom servers and clients for their needs
  * I'm not a big fan of "quickstart" in general since these might not be quick tasks, but with the limited time I didn't want to spend it changing directory and file names. If this were a bigger project, renaming this content would be important to me so that users identify it as a learning path that can get them up to speed with MCP
* **Explore MCP**
  * Since this is more technical and not really needed to jump into the quickstarts, I moved the general architecture to this setting. It's still easily discoverable, but it doesn't get in the way of people who want to get to trying things quickly and it doesn't scare away people who think the mermaid diagram is too technical for their understanding
* **Tutorials**
  * Added an intro line explaining a bit of what tutorials are for versus quickstarts. With more time, disambiguating these two categories would probably help users

What I abandoned
* I started to write a whole new quickstart, but realized that the three existing ones have a good flow of scaffolding skills if you go through each of them. They just weren't being presented in the order that made the most sense
* The new article I was working on was going to be too similar to the desktop quickstart, so rather than add a specific quickstart for the less experienced audience, it seemed more efficient and supports their jobs to be done to reorganize the existing content

Assumed jobs to be done
* I quickly sketched out these jobs to be done for the audience
  * "As a less experienced software developer, I want to understand what MCP is, so that I can be aware of and use industry best practices while preparing for my career"
  * "As a less technical employee, I want to understand MCP, so that I can communicate with my engineering team about the capacity and possibilities of the technology"
* By making the conceptual content a bit more skimmable with keywords and guiding people toward a structured path through the procedural content, we can help people recognize these JTBD by giving them a quick overview without as much technical content and a pathway to grow their understanding